### PR TITLE
CI: super-linter - disable trivy and zizmor

### DIFF
--- a/.github/workflows/docker.image.yml
+++ b/.github/workflows/docker.image.yml
@@ -49,6 +49,8 @@ jobs:
         env:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+          VALIDATE_TRIVY: false
   shiftleft:
     name: shiftleft
     strategy:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Disable Trivy and Zizmor validation in the Docker image workflow